### PR TITLE
Introduce a routes convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,48 @@ The idea of the app is an asynchronous conversation app. The general design is i
 
 ![](./AppVisualizing.jpg)
 
-## The Guide
+---
+
+## Development Setup
+
+Clone down this repo, then install the modules:
+```bash
+npm install
+```
+
+Start the API in dev-mode:
+```bash
+npm run dev
+```
+
+For testing:
+```bash
+npm test
+```
+
+## API
+
+  | ROUTE                  | HTTP METHOD | PURPOSE
+--|------------------------|-------------|---------------------------
+✓ | /podcast               | GET         | Get all podcasts
+✓ | /podcast               | POST        | Create a new podcast
+  | /podcast/:id           | GET         | Get a particular podcast
+✓ | /podcast/:id           | PUT         | Update a particular podcast
+✓ | /podcast/:id           | DELETE      | Tombstone a particular podcast
+  |                        |             |
+  | /podcast/:id/comment   | GET         | Get all comment associated with a particular podcast
+✓ | /podcast/:id/comment   | POST        | Create a comment associated with a particular podcast
+  |                        |             |
+✓ | /comment               | GET         | Get all podcasts
+✓ | /comment/:id           | GET         | Get a particular comment
+✓ | /comment/:id           | PUT         | Update a particular comment
+✓ | /comment/:id           | DELETE      | Tombstone a particular comment
+
+If you want to get the ten latest comments you can use queries e.g.  `GET` to `/comment?limit=10`
+
+---
+
+## The Guide (Roadmap)
 
 ### Step 0 - Setting up the base
 

--- a/api/index.js
+++ b/api/index.js
@@ -11,7 +11,7 @@ const SSB = require('../ssb') // ".." goes backwards to the ssb.js file that is 
 const podcastModel = require('./podcast-model') // related to the crut framework, it tells the crut how it should be able to work with "podcasts", could also be "gatherings" or "posts", hypothetically. It automatically knows that it's a .json so no need to write out
 
 const commentModel = require('./commentModel') // links to the dependancies for the object Comment (which is created later on) in this case "commentModel"
-const { length } = require('ssb-db2')
+// const { length } = require('ssb-db2')
 
 // all above is just setting up what we're using, the following is starting to use it
 
@@ -36,12 +36,12 @@ app.get('/whoami', (req, res) => {
 // THIS ONE IS THE BASE FOR GETTING COMMENTS FOR SPECIFIC PODCAST
 
 // app.get defines the function for the remaining usage where one can for example call comments/15 or comments/7 to call for podcast nr 15 or nr 7
-app.get('/comments/:podcastId', async (req, res) => {
+app.get('/comment/:id', async (req, res) => {
   const { where, and, slowEqual, type, toPromise } = require('ssb-db2/operators') // enables the commands to be used
   let comments = await ssb.db.query(
     where( // select inside the list with the requirements of multiple things, "and"
       and( // two things need to be true
-        slowEqual('value.content.podcastId.set', req.params.podcastId), // find a specific field //"value.content.podcastId.set" says what page in the book to look at and "req.params.podcastId" is what specific podcast ID it is
+        slowEqual('value.content.podcastId.set', req.params.id), // find a specific field //"value.content.podcastId.set" says what page in the book to look at and "req.params.podcastId" is what specific podcast ID it is
         type('comment') // specifically comments
       )
     ), toPromise() // whenever it has promised the await is waiting the responses
@@ -56,10 +56,8 @@ app.get('/comments/:podcastId', async (req, res) => {
   res.send({ comments }) // only gives back the comment text, could also show author, which is automatically added to the messages in ssb
 })
 
-
-
 // THIS ONE IS THE BASE FOR GETTING ALL COMMENTS
-app.get('/comments', async (req, res) => {
+app.get('/comment', async (req, res) => {
   const { where, and, type, toPromise } = require('ssb-db2/operators') // enables the commands to be used
   let comments = await ssb.db.query( // used to be "const" instead of "let"
     where( // select inside the list with the requirements of multiple things, "and"
@@ -71,30 +69,12 @@ app.get('/comments', async (req, res) => {
   comments = comments.filter(msg => {
     return msg.value.content.tangles.comment.root === null // comparing to see if it's equal, if it is, then true
   }) // filter works on arrays, only keeps some elements if it returns true you want to keep it if it returns false, you don't want to keep the messages of the array
+
+  if (req.query.limit) comments = comments.slice(0, req.query.limit)
 
   comments = await Promise.all(comments.map(msg => commentCrut.read(msg.key))) // with each of these messages, use crut to load the comments, please!
   res.send({ comments }) // only gives back the comment text, could also show author, which is automatically added to the messages in ssb
 })
-
-
-
-// THIS ONE IS THE BASE FOR GETTING 10 LATEST COMMENTS (using crut)
-app.get('/10LatestCommentsCrut', async (req, res) => {
-  const { where, and, type, toPromise } = require('ssb-db2/operators') // enables the commands to be used
-  let comments = await ssb.db.query( // used to be "const" instead of "let"
-    where( // select inside the list with the requirements of multiple things, "and"
-      and( // two things need to be true
-        type('comment') // specifically comments
-      )
-    ), toPromise() // whenever it has promised the await is waiting the responses
-  )
-  comments = comments.filter(msg => {
-    return msg.value.content.tangles.comment.root === null // comparing to see if it's equal, if it is, then true
-  }) // filter works on arrays, only keeps some elements if it returns true you want to keep it if it returns false, you don't want to keep the messages of the array
-  comments = comments.slice(-10)
-  res.send({ comments }) // only gives back the comment text, could also show author, which is automatically added to the messages in ssb
-})
-
 
 // nicer solution is https://github.com/ssb-ngi-pointer/jitdb#pagination - let's you call 10 msgs at a time, can also do oldest first
 
@@ -141,7 +121,7 @@ app.get('/10LatestComments', async (req, res) => {
 
 // THE BASE FOR GETTING LIST OF PODCASTS
 
-app.get('/podcasts', async (req, res) => {
+app.get('/podcast', async (req, res) => {
   const { where, and, type, toPromise } = require('ssb-db2/operators') // enables the commands to be used
   const podcast = await ssb.db.query(
     where( // select inside the list with the requirements of multiple things, "and"
@@ -173,29 +153,31 @@ app.post('/podcast', (req, res) => {
 
 // THIS IS THE BASE FOR MAKING COMMENT POSTS
 
-app.post('/comment', (req, res) => {
-  const { comment, podcastId } = req.body
+app.post('/podcast/:id/comment', (req, res) => {
+  const { id } = req.params
+  const { comment } = req.body
 
-  commentCrut.create({ comment, podcastId }, (err, commentId) => { // here is where it changes, it needs to reference the previous podcast ID as well as create a new ID. This means that the code should be a part of the "podcast" section I believe
+  commentCrut.create({ comment, podcastId: id }, (err, commentId) => { // here is where it changes, it needs to reference the previous podcast ID as well as create a new ID. This means that the code should be a part of the "podcast" section I believe
     if (err) res.send(err)
-    else res.send({ id: commentId, message: `Your comment ID is ${commentId} and your podcast ID is ${podcastId}` })
+    else res.send({ id: commentId, message: `Your comment ID is ${commentId} and your podcast ID is ${id}` })
   })
 })
 
 // THIS IS THE BASE FOR UPDATING PODCAST POSTS
 
-app.post('/podcastUpdate', (req, res) => {
-  const { title, url, podcastId, description } = req.body
+app.put('/podcast/:id', (req, res) => {
+  const { id } = req.params
+  const { title, url, description } = req.body
   // my thinking is that it has to update the podcastId, check if it can find it and if it does find it replace it with the newPodcastID
-  podcast.update(podcastId, { title, url, description }, (err) => {
+  podcast.update(id, { title, url, description }, (err) => {
     if (err) {
       res.send(err)
       return // return here means don't continue the function, stop here.
     }
 
-    podcast.read(podcastId, (err) => {
+    podcast.read(id, (err) => {
       if (err) res.send(err)
-      else res.send({ id: podcastId, message: `Your podcast ID is ${podcastId} and the podcast has been updated`, description }) // 000 where is the podcast ID defined?
+      else res.send({ id, message: `Your podcast ID is ${id} and the podcast has been updated`, description }) // 000 where is the podcast ID defined?
       // 000 where are the podcasts stored? what defines it as "podcasts"
     })
   })
@@ -203,15 +185,15 @@ app.post('/podcastUpdate', (req, res) => {
 
 // THIS IS THE BASE FOR UPDATING COMMENT POSTS
 
-app.post('/commentUpdate', (req, res) => {
-  const { commentId, comment } = req.body
+app.put('/comment/:id', (req, res) => {
+  const { id } = req.params
+  const { comment } = req.body
   // my thinking is that it has to update the podcastId, check if it can find it and if it does find it replace it with the newPodcastID
-  console.log('You got the ${commentId}')
-  commentCrut.update(commentId, { comment }, (err) => {
+  commentCrut.update(id, { comment }, (err) => {
     console.log(`got ${err}`)
-    commentCrut.read(commentId, (err, updatedComment) => {
+    commentCrut.read(id, (err, updateId) => {
       if (err) res.send(err)
-      else res.send({ id: commentId, message: `Your comment ID is ${commentId} and the comment has been updated`, comment }) // 000 where is the podcast ID defined?
+      else res.send({ id, message: `Your comment ID is ${id} and the comment has been updated`, comment }) // 000 where is the podcast ID defined?
       // 000 where are the podcasts stored? what defines it as "podcasts"
       console.log(`got 2 ${err}`)
     })
@@ -220,22 +202,22 @@ app.post('/commentUpdate', (req, res) => {
 
 // THIS IS THE BASE FOR TOMBSTONING PODCAST POSTS
 
-app.post('/podcastTombstone', (req, res) => {
-  const { podcastId } = req.body
+app.delete('/podcast/:id', (req, res) => {
+  const { id } = req.params
 
-  podcast.tombstone(podcastId, {}, (err) => {
+  podcast.tombstone(id, {}, (err) => {
     if (err) res.send(err)
-    else res.send({ id: podcastId, message: `You have removed ${podcastId}` }) // tombstones the podcast?????
+    else res.send({ id, message: `You have removed podcast ${id}` }) // tombstones the podcast?????
   })
 })
 
 // THIS IS THE BASE FOR TOMBSTONING COMMENT POSTS
 
-app.post('/commentTombstone', (req, res) => {
-  const { commentId, podcastId } = req.body
-  commentCrut.tombstone(commentId, {}, (err) => {
+app.delete('/comment/:id', (req, res) => {
+  const { id } = req.params
+  commentCrut.tombstone(id, {}, (err) => {
     if (err) res.send(err)
-    else res.send({ id: commentId, message: `You have removed the following comment "${commentId}" from the podcast with the following ID: ${podcastId}` }) // tombstones the comment?????
+    else res.send({ id, message: `You have removed the following comment "${id}"` }) // tombstones the comment?????
   })
 })
 
@@ -248,7 +230,6 @@ app.listen(3000) // listens to local host port 3000
 console.log('API running on http://localhost:3000/')
 
 // TASK for NEXT WEEK:
-
 
 // - Latest 10 comments no matter the podcast (won't work unless we reorder the )
 


### PR DESCRIPTION
This PR changes the names + methods of the API's routes to make them follow a more RESTful pattern.
You can of course make name the API endpoints/ routes whatever you want, it's just this approach means you're using a common pattern which gives easy to predict names to API routes. (good naming is one of the hardest problems!) 

One change to pay attnetion to is that I added new  HTTP Methods:
- `PUT` - this means "I am sending you an update to an existing record" 
    - e.g. `app.put('/comment/:id, (req, res) => {....})`
- `DELETE` - this means "I am asking you to delete a particular record"
_(You already had `GET` for retrieving data and `POST` for creating records)_

Have @arj03 or I go through how to review and merge a Pull Request, or have a click around yourself (you can't break anything)